### PR TITLE
Use full module namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"jami/pkg/screens"
+	"github.com/mehrdad-dev/Jami/pkg/screens"
 	"os"
 
 	"fyne.io/fyne"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module jami
+module github.com/mehrdad-dev/Jami
 
 go 1.12
 

--- a/pkg/screens/Keyboard.go
+++ b/pkg/screens/Keyboard.go
@@ -1,7 +1,7 @@
 package screens
 
 import (
-	"jami/pkg/sound"
+	"github.com/mehrdad-dev/Jami/pkg/sound"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/layout"

--- a/pkg/screens/home.go
+++ b/pkg/screens/home.go
@@ -2,7 +2,7 @@ package screens
 
 import (
 	"fmt"
-	"jami/pkg/sound"
+	"github.com/mehrdad-dev/Jami/pkg/sound"
 
 	"fyne.io/fyne"
 	"fyne.io/fyne/layout"

--- a/pkg/screens/settings.go
+++ b/pkg/screens/settings.go
@@ -2,7 +2,7 @@ package screens
 
 import (
 	"fmt"
-	"jami/pkg/sound"
+	"github.com/mehrdad-dev/Jami/pkg/sound"
 	"os"
 
 	"fyne.io/fyne"


### PR DESCRIPTION
This change means that the app can be "go get" or "fyne get" without needing to download the code first.